### PR TITLE
knova is expecting epoch date in milliseconds rather than seconds 

### DIFF
--- a/lib/pgcd.js
+++ b/lib/pgcd.js
@@ -106,7 +106,7 @@ convertOracleTimestamps = function(data, callback) {
 			log.warn('Skipping date conversion for \'' + element + '\': incorrect document ID format.');
 			skippedDocs.push(new Doc(element[0], element[1]));
 		} else {
-			doc = new Doc(element[0], date.unix());
+			doc = new Doc(element[0], date.valueOf()); // unix/epoch date in milliseconds
 			result.push(doc);
 			log.info('Data is verified and new Doc has been pushed to list.');
 		}


### PR DESCRIPTION
I've tested manually with the date in milliseconds vs seconds and it works with milliseconds. What I was forgetting to do yesterday in our manual tests was to `COMMIT` my Oracle transaction (derp derp).

Having moment convert to unix/epoch date in milliseconds will do the trick:
http://momentjs.com/docs/#/displaying/unix-timestamp-milliseconds/

### My two tests

[TID 7020968](https://www.novell.com/support/kb/doc.php?id=7020968) - shows correctly '23-FEB-16'
Update statement using epoch/unix time in milliseconds:
```sql
UPDATE KADMIN.DOCUMENT
SET CREATED = '1456210800442'
WHERE DOCUMENTID = '7020968';
COMMIT;
```
I then ran the recontribute.

--
[TID 7020967](https://www.novell.com/support/kb/doc.php?id=7020967) - shows correctly '27-MAY-08'
Update statement using epoch/unix time in milliseconds:
```sql
UPDATE KADMIN.DOCUMENT
SET CREATED = '1211868000000'
WHERE DOCUMENTID = '7020967';
COMMIT;
```
I then ran the recontribute.

### Result
This should fix the issue and then we are set to test more! :)